### PR TITLE
Request decoder

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"regexp"
+
+	"github.com/achilleasa/mongolite/protocol"
+	"github.com/davecgh/go-spew/spew"
+	"golang.org/x/xerrors"
+	"gopkg.in/urfave/cli.v2"
+)
+
+// AnalyzeStream implements the analyze tool CLI command.
+func AnalyzeStream(ctx *cli.Context) error {
+	var reqStream io.Reader
+
+	if ctx.NArg() != 1 {
+		return xerrors.Errorf("No input file specified")
+	}
+
+	reqFile := ctx.Args().First()
+	if reqFile == "-" {
+		appLogger.WithField("from", "STDIN").Info("reading captured stream data")
+		reqStream = os.Stdin
+	} else {
+		f, err := os.Open(reqFile)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = f.Close() }()
+		reqStream = f
+		appLogger.WithField("from", reqFile).Info("reading captured stream data")
+	}
+
+	// Parse options
+	var (
+		offset    = ctx.Int("offset")
+		limit     = ctx.Int("limit")
+		filterMap map[protocol.RequestType]bool
+	)
+	if filterList := ctx.StringSlice("filter"); len(filterList) != 0 {
+		filterMap = make(map[protocol.RequestType]bool)
+		for _, filter := range filterList {
+			switch protocol.RequestType(filter) {
+			case protocol.RequestTypeUpdate, protocol.RequestTypeInsert,
+				protocol.RequestTypeQuery, protocol.RequestTypeGetMore,
+				protocol.RequestTypeDelete, protocol.RequestTypeKillCursors,
+				protocol.RequestTypeCommand, protocol.RequestTypeUnknown:
+			default:
+				return xerrors.Errorf("unknown request type %q in --filter parameter", filter)
+			}
+			filterMap[protocol.RequestType(filter)] = true
+		}
+	}
+
+	return analyze(reqStream, offset, limit, filterMap)
+}
+
+func analyze(reqStream io.Reader, offset, limit int, filterMap map[protocol.RequestType]bool) error {
+	// Apply requested offset
+	for i := 0; i < offset; i++ {
+		var rLen int32
+		if err := binary.Read(reqStream, binary.LittleEndian, &rLen); err != nil {
+			if err == io.EOF {
+				break // tried to seek beyond EOF
+			}
+			return xerrors.Errorf("unable to read size of request %d: %w", i+1, err)
+		}
+
+		// Skip captured payload
+		if _, err := io.CopyN(ioutil.Discard, reqStream, int64(rLen)); err != nil {
+			return xerrors.Errorf("unable to skip over request %d: %w", i+1, err)
+		}
+	}
+
+	// Run decode loop
+	var (
+		buf      bytes.Buffer
+		indentRe = regexp.MustCompile("(?m)^")
+	)
+	for i := 0; ; i++ {
+		if limit != 0 && i == limit {
+			break
+		}
+
+		var rLen int32
+		if err := binary.Read(reqStream, binary.LittleEndian, &rLen); err != nil {
+			if err == io.EOF {
+				break // tried to seek beyond EOF
+			}
+			return xerrors.Errorf("unable to read of request %d: %w", i+offset+1, err)
+		}
+
+		buf.Reset()
+		if _, err := io.CopyN(&buf, reqStream, int64(rLen)); err != nil {
+			return xerrors.Errorf("unable to read request %d: %w", i+offset+1, err)
+		}
+
+		req, err := protocol.Decode(buf.Bytes())
+		if err != nil {
+			return xerrors.Errorf("unable to decode request %d: %w", i+offset+1, err)
+		}
+
+		// Apply filtering
+		if filterMap != nil && !filterMap[req.Type()] {
+			continue
+		}
+
+		reqDump := indentRe.ReplaceAllString(spew.Sdump(req), "  ")
+		fmt.Printf("[+] request: %05d, type %q (opcode: %d)\n%s\n", i, req.Type(), req.Opcode(), reqDump)
+	}
+
+	return nil
+}

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -44,14 +44,14 @@ func AnalyzeStream(ctx *cli.Context) error {
 		filterMap map[protocol.RequestType]bool
 	)
 	if filterList := ctx.StringSlice("filter"); len(filterList) != 0 {
+		knownReqTypes := make(map[string]struct{})
+		for _, rType := range protocol.AllRequestTypeNames() {
+			knownReqTypes[rType] = struct{}{}
+		}
+
 		filterMap = make(map[protocol.RequestType]bool)
 		for _, filter := range filterList {
-			switch protocol.RequestType(filter) {
-			case protocol.RequestTypeUpdate, protocol.RequestTypeInsert,
-				protocol.RequestTypeQuery, protocol.RequestTypeGetMore,
-				protocol.RequestTypeDelete, protocol.RequestTypeKillCursors,
-				protocol.RequestTypeCommand, protocol.RequestTypeUnknown:
-			default:
+			if _, valid := knownReqTypes[filter]; !valid {
 				return xerrors.Errorf("unknown request type %q in --filter parameter", filter)
 			}
 			filterMap[protocol.RequestType(filter)] = true

--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"os"
+
+	"gopkg.in/Sirupsen/logrus.v1"
+	"gopkg.in/urfave/cli.v2"
+)
+
+var (
+	rootLogger = logrus.New()
+	appLogger  = rootLogger.WithField("module", "app")
+)
+
+// SetupLogger is invoked by the cli before a command is executed.
+func SetupLogger(*cli.Context) error {
+	rootLogger.SetOutput(os.Stderr)
+	return nil
+}
+
+// ExitErrorHandler is invoked when the cli encounters a fatal error.
+func ExitErrorHandler(_ *cli.Context, err error) {
+	appLogger.WithError(err).Errorf("terminating due to error")
+	os.Exit(1)
+}

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/achilleasa/mongolite/handler"
+	"github.com/achilleasa/mongolite/proxy"
+	"golang.org/x/xerrors"
+	"gopkg.in/urfave/cli.v2"
+)
+
+// ProxyToRemote implements the proxy tool CLI command.
+func ProxyToRemote(ctx *cli.Context) error {
+	mongoHandler, err := makeRemoteMongoHandler(ctx)
+	if err != nil {
+		return err
+	}
+
+	recReqFile := ctx.String("rec-requests-to")
+	recResFile := ctx.String("rec-responses-to")
+	if recReqFile != "" || recResFile != "" {
+		var reqStream, resStream = ioutil.Discard, ioutil.Discard
+		if recReqFile != "" {
+			f, err := os.Create(recReqFile)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = f.Close() }()
+			reqStream = f
+
+			appLogger.WithField("to", recReqFile).Info("recording client requests")
+		}
+		if recResFile != "" {
+			f, err := os.Create(recResFile)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = f.Close() }()
+			resStream = f
+
+			appLogger.WithField("to", recResFile).Info("recording server responses")
+		}
+
+		// Wrap mongo proxy handler with a stream recorder.
+		mongoHandler = handler.NewRecorder(reqStream, resStream, mongoHandler)
+	}
+
+	return startProxy(ctx, mongoHandler)
+}
+
+func makeRemoteMongoHandler(ctx *cli.Context) (proxy.RequestHandler, error) {
+	var (
+		remoteTlsConf *tls.Config
+		err           error
+	)
+	if pemFile := ctx.String("remote-tls-file"); pemFile != "" {
+		if remoteTlsConf, err = parseMongoPemFile(pemFile, ctx.String("remote-tls-file-password")); err != nil {
+			return nil, err
+		}
+
+		if ctx.Bool("remote-tls-no-verify") {
+			appLogger.Warn("disabling TLS verification when connecting to remote mongod")
+			remoteTlsConf.InsecureSkipVerify = true
+		}
+	}
+
+	return handler.NewRemoteMongoHandler(
+		ctx.String("remote-address"),
+		remoteTlsConf,
+	)
+}
+
+func startProxy(ctx *cli.Context, reqHandler proxy.RequestHandler) error {
+	var (
+		proxyTlsConf *tls.Config
+		err          error
+	)
+
+	if pemFile := ctx.String("listen-tls-file"); pemFile != "" {
+		if proxyTlsConf, err = parseMongoPemFile(pemFile, ctx.String("listen-tls-file-password")); err != nil {
+			return err
+		}
+	}
+
+	proxyConf, err := proxy.NewConfig(
+		proxy.WithListenAddress(ctx.String("listen-address")),
+		proxy.WithRequestHandler(reqHandler),
+		proxy.WithTLS(proxyTlsConf),
+		proxy.WithLogger(rootLogger.WithField("module", "proxy")),
+	)
+	if err != nil {
+		return err
+	}
+
+	srvCtx := signalAwareContext(context.Background())
+	return proxy.NewServer(proxyConf).Listen(srvCtx)
+}
+
+func parseMongoPemFile(pemFile, password string) (*tls.Config, error) {
+	data, err := ioutil.ReadFile(pemFile)
+	if err != nil {
+		return nil, xerrors.Errorf("unable to parse mongo TLS cert from %s: %w", pemFile, err)
+	}
+
+	var (
+		nextBlock  *pem.Block
+		serverCert []byte
+		privateKey []byte
+	)
+	for {
+		if nextBlock, data = pem.Decode(data); nextBlock == nil {
+			break // No more PEM blocks available
+		}
+
+		if x509.IsEncryptedPEMBlock(nextBlock) {
+			if password == "" {
+				return nil, xerrors.Errorf("unable to parse mongo TLS cert from %s: contents are encrypted but no password was provided", pemFile)
+			}
+
+			if nextBlock.Bytes, err = x509.DecryptPEMBlock(nextBlock, []byte(password)); err != nil {
+				return nil, xerrors.Errorf("unable to parse mongo TLS cert from %s: pem block decryption failed: %w", pemFile, err)
+			}
+		}
+
+		switch nextBlock.Type {
+		case "CERTIFICATE":
+			serverCert = pem.EncodeToMemory(nextBlock)
+		case "RSA PRIVATE KEY":
+			privateKey = pem.EncodeToMemory(nextBlock)
+		default:
+			return nil, xerrors.Errorf("unable to parse mongo TLS cert from %s: unexpected pem block of type %q", pemFile, nextBlock.Type)
+		}
+	}
+
+	if serverCert == nil {
+		return nil, xerrors.Errorf("unable to parse mongo TLS cert from %s: missing server certificate", pemFile)
+	} else if privateKey == nil {
+		return nil, xerrors.Errorf("unable to parse mongo TLS cert from %s: missing private key", pemFile)
+	}
+
+	cert, err := tls.X509KeyPair(serverCert, privateKey)
+	if err != nil {
+		return nil, xerrors.Errorf("unable to parse mongo TLS cert from %s: unable to parse x509 keypair: %w", pemFile, err)
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}, nil
+}
+
+func signalAwareContext(ctx context.Context) context.Context {
+	wrappedCtx, cancelFn := context.WithCancel(ctx)
+	go func() {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGINT)
+		s := <-sigCh
+		appLogger.WithField("signal", s.String()).Info("terminating due to signal")
+		cancelFn()
+	}()
+	return wrappedCtx
+}

--- a/main.go
+++ b/main.go
@@ -33,6 +33,22 @@ func main() {
 						Action:   cmd.ProxyToRemote,
 						Category: "tools",
 					},
+					&cli.Command{
+						Name:      "analyze",
+						ArgsUsage: "FILE",
+						Usage:     "Decode and analyze recorded requests",
+						Description: `
+Decode and analyze recorded mongo client request stream from FILE. If a value 
+of '-' is provided for the FILE argument, the tool will read the request stream
+from STDIN`,
+						Flags: []cli.Flag{
+							&cli.IntFlag{Name: "offset", Value: 0, Usage: "number of request entries to skip"},
+							&cli.IntFlag{Name: "limit", Value: 0, Usage: "number of request entries to display; if 0 all entries will be displayed"},
+							&cli.StringSliceFlag{Name: "filter", Usage: "only show requests of `TYPE`. Supported types: insert, update, delete, query, getMore, killCursors, command, unknown"},
+						},
+						Action:   cmd.AnalyzeStream,
+						Category: "tools",
+					},
 				},
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -1,25 +1,8 @@
 package main
 
 import (
-	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/pem"
-	"io/ioutil"
-	"os"
-	"os/signal"
-	"syscall"
-
-	"github.com/achilleasa/mongolite/handler"
-	"github.com/achilleasa/mongolite/proxy"
-	"golang.org/x/xerrors"
-	"gopkg.in/Sirupsen/logrus.v1"
+	"github.com/achilleasa/mongolite/cmd"
 	"gopkg.in/urfave/cli.v2"
-)
-
-var (
-	rootLogger = logrus.New()
-	appLogger  = rootLogger.WithField("module", "app")
 )
 
 func main() {
@@ -47,166 +30,15 @@ func main() {
 							&cli.StringFlag{Name: "rec-requests-to", Value: "", Usage: "a filename for recroding client requests (only if specified)"},
 							&cli.StringFlag{Name: "rec-responses-to", Value: "", Usage: "a filename for recording server responses (only if specified)"},
 						},
-						Action: proxyToRemote,
+						Action:   cmd.ProxyToRemote,
+						Category: "tools",
 					},
 				},
 			},
 		},
+		Before:         cmd.SetupLogger,
+		ExitErrHandler: cmd.ExitErrorHandler,
 	}
 
-	rootLogger.SetOutput(os.Stderr)
-	if err := app.Run(os.Args); err != nil {
-		appLogger.WithError(err).Errorf("terminating due to error")
-		os.Exit(1)
-	}
-}
-
-func proxyToRemote(ctx *cli.Context) error {
-	mongoHandler, err := makeRemoteMongoHandler(ctx)
-	if err != nil {
-		return err
-	}
-
-	recReqFile := ctx.String("rec-requests-to")
-	recResFile := ctx.String("rec-responses-to")
-	if recReqFile != "" || recResFile != "" {
-		var reqStream, resStream = ioutil.Discard, ioutil.Discard
-		if recReqFile != "" {
-			f, err := os.Create(recReqFile)
-			if err != nil {
-				return err
-			}
-			defer func() { _ = f.Close() }()
-			reqStream = f
-
-			appLogger.WithField("to", recReqFile).Info("recording client requests")
-		}
-		if recResFile != "" {
-			f, err := os.Create(recResFile)
-			if err != nil {
-				return err
-			}
-			defer func() { _ = f.Close() }()
-			resStream = f
-
-			appLogger.WithField("to", recResFile).Info("recording server responses")
-		}
-
-		// Wrap mongo proxy handler with a stream recorder.
-		mongoHandler = handler.NewRecorder(reqStream, resStream, mongoHandler)
-	}
-
-	return startProxy(ctx, mongoHandler)
-}
-
-func makeRemoteMongoHandler(ctx *cli.Context) (proxy.RequestHandler, error) {
-	var (
-		remoteTlsConf *tls.Config
-		err           error
-	)
-	if pemFile := ctx.String("remote-tls-file"); pemFile != "" {
-		if remoteTlsConf, err = parseMongoPemFile(pemFile, ctx.String("remote-tls-file-password")); err != nil {
-			return nil, err
-		}
-
-		if ctx.Bool("remote-tls-no-verify") {
-			appLogger.Warn("disabling TLS verification when connecting to remote mongod")
-			remoteTlsConf.InsecureSkipVerify = true
-		}
-	}
-
-	return handler.NewRemoteMongoHandler(
-		ctx.String("remote-address"),
-		remoteTlsConf,
-	)
-}
-
-func startProxy(ctx *cli.Context, reqHandler proxy.RequestHandler) error {
-	var (
-		proxyTlsConf *tls.Config
-		err          error
-	)
-
-	if pemFile := ctx.String("listen-tls-file"); pemFile != "" {
-		if proxyTlsConf, err = parseMongoPemFile(pemFile, ctx.String("listen-tls-file-password")); err != nil {
-			return err
-		}
-	}
-
-	proxyConf, err := proxy.NewConfig(
-		proxy.WithListenAddress(ctx.String("listen-address")),
-		proxy.WithRequestHandler(reqHandler),
-		proxy.WithTLS(proxyTlsConf),
-		proxy.WithLogger(rootLogger.WithField("module", "proxy")),
-	)
-	if err != nil {
-		return err
-	}
-
-	srvCtx := signalAwareContext(context.Background())
-	return proxy.NewServer(proxyConf).Listen(srvCtx)
-}
-
-func parseMongoPemFile(pemFile, password string) (*tls.Config, error) {
-	data, err := ioutil.ReadFile(pemFile)
-	if err != nil {
-		return nil, xerrors.Errorf("unable to parse mongo TLS cert from %s: %w", pemFile, err)
-	}
-
-	var (
-		nextBlock  *pem.Block
-		serverCert []byte
-		privateKey []byte
-	)
-	for {
-		if nextBlock, data = pem.Decode(data); nextBlock == nil {
-			break // No more PEM blocks available
-		}
-
-		if x509.IsEncryptedPEMBlock(nextBlock) {
-			if password == "" {
-				return nil, xerrors.Errorf("unable to parse mongo TLS cert from %s: contents are encrypted but no password was provided", pemFile)
-			}
-
-			if nextBlock.Bytes, err = x509.DecryptPEMBlock(nextBlock, []byte(password)); err != nil {
-				return nil, xerrors.Errorf("unable to parse mongo TLS cert from %s: pem block decryption failed: %w", pemFile, err)
-			}
-		}
-
-		switch nextBlock.Type {
-		case "CERTIFICATE":
-			serverCert = pem.EncodeToMemory(nextBlock)
-		case "RSA PRIVATE KEY":
-			privateKey = pem.EncodeToMemory(nextBlock)
-		default:
-			return nil, xerrors.Errorf("unable to parse mongo TLS cert from %s: unexpected pem block of type %q", pemFile, nextBlock.Type)
-		}
-	}
-
-	if serverCert == nil {
-		return nil, xerrors.Errorf("unable to parse mongo TLS cert from %s: missing server certificate", pemFile)
-	} else if privateKey == nil {
-		return nil, xerrors.Errorf("unable to parse mongo TLS cert from %s: missing private key", pemFile)
-	}
-
-	cert, err := tls.X509KeyPair(serverCert, privateKey)
-	if err != nil {
-		return nil, xerrors.Errorf("unable to parse mongo TLS cert from %s: unable to parse x509 keypair: %w", pemFile, err)
-	}
-
-	return &tls.Config{
-		Certificates: []tls.Certificate{cert},
-	}, nil
-}
-
-func signalAwareContext(ctx context.Context) context.Context {
-	wrappedCtx, cancelFn := context.WithCancel(ctx)
-	go func() {
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGINT)
-		s := <-sigCh
-		appLogger.WithField("signal", s.String()).Info("terminating due to signal")
-		cancelFn()
-	}()
-	return wrappedCtx
+	app.RunAndExitOnError()
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/achilleasa/mongolite/cmd"
+	"github.com/achilleasa/mongolite/protocol"
 	"gopkg.in/urfave/cli.v2"
 )
 
@@ -44,7 +47,7 @@ from STDIN`,
 						Flags: []cli.Flag{
 							&cli.IntFlag{Name: "offset", Value: 0, Usage: "number of request entries to skip"},
 							&cli.IntFlag{Name: "limit", Value: 0, Usage: "number of request entries to display; if 0 all entries will be displayed"},
-							&cli.StringSliceFlag{Name: "filter", Usage: "only show requests of `TYPE`. Supported types: insert, update, delete, query, getMore, killCursors, command, unknown"},
+							&cli.StringSliceFlag{Name: "filter", Usage: "only show requests of `TYPE`. Supported types: " + strings.Join(protocol.AllRequestTypeNames(), ", ")},
 						},
 						Action:   cmd.AnalyzeStream,
 						Category: "tools",

--- a/protocol/decode_cmd.go
+++ b/protocol/decode_cmd.go
@@ -1,0 +1,146 @@
+package protocol
+
+import (
+	"golang.org/x/xerrors"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// decodeInsertCommand decodes an insert command packed within a query operation
+// using the schema described in https://docs.mongodb.com/manual/reference/command/insert/#dbcmd.insert.
+func decodeInsertCommand(hdr header, nsCol NamespacedCollection, cmdArgs bson.M) (Request, error) {
+	docList, isDocList := cmdArgs["documents"].([]interface{})
+	if !isDocList {
+		return nil, xerrors.Errorf("malformed insert command in query doc: invalid doc list")
+	}
+	docs := make([]bson.M, len(docList))
+	for i, d := range docList {
+		doc, isDoc := d.(bson.D)
+		if !isDoc {
+			return nil, xerrors.Errorf("malformed insert command in query doc: invalid doc at index %d", i)
+		}
+		docs[i] = doc.Map()
+	}
+
+	req := &InsertRequest{
+		// This request requires a reply to be sent back to the client
+		requestBase: requestBase{h: hdr, reqType: RequestTypeInsert, replyExpected: true},
+		Collection:  nsCol,
+		Inserts:     docs,
+	}
+
+	if ordered, valid := cmdArgs["ordered"].(bool); valid && !ordered {
+		req.Flags |= InsertFlagContinueOnError
+	}
+
+	return req, nil
+}
+
+// decodeUpdateCommand decodes an update command packed within a query operation
+// using the schema described in https://docs.mongodb.com/manual/reference/command/update/#dbcmd.update
+func decodeUpdateCommand(hdr header, nsCol NamespacedCollection, cmdArgs bson.M) (Request, error) {
+	updatesDoc, valid := cmdArgs["updates"].([]interface{})
+	if !valid {
+		return nil, xerrors.Errorf("malformed update command in query doc: invalid updates list")
+	}
+
+	updateTargets := make([]UpdateTarget, len(updatesDoc))
+	for i := 0; i < len(updatesDoc); i++ {
+		updateDoc, valid := updatesDoc[i].(bson.D)
+		if !valid {
+			return nil, xerrors.Errorf("malformed update command in query doc: invalid update doc at index %d", i)
+		}
+
+		updateDocMap := updateDoc.Map()
+		if q, valid := updateDocMap["q"].(bson.D); valid {
+			updateTargets[i].Selector = q.Map()
+		}
+		if u, valid := updateDocMap["u"].(bson.D); valid {
+			updateTargets[i].Update = u.Map()
+		}
+		if upsert, valid := updateDocMap["upsert"].(bool); valid && upsert {
+			updateTargets[i].Flags |= UpdateFlagUpsert
+		}
+		if multi, valid := updateDocMap["multi"].(bool); valid && multi {
+			updateTargets[i].Flags |= UpdateFlagMulti
+		}
+		if arrayFilterList, valid := cmdArgs["arrayFilters"].([]interface{}); valid {
+			for j, fdoc := range arrayFilterList {
+				arrayFilter, valid := fdoc.(bson.D)
+				if !valid {
+					return nil, xerrors.Errorf("malformed update command in query doc: invalid update doc at index %d: invalid array filter at index %d", i, j)
+				}
+				updateTargets[i].ArrayFilters = append(updateTargets[i].ArrayFilters, arrayFilter.Map())
+			}
+		}
+	}
+
+	return &UpdateRequest{
+		requestBase: requestBase{h: hdr, reqType: RequestTypeUpdate, replyExpected: true},
+		Collection:  nsCol,
+		Updates:     updateTargets,
+	}, nil
+}
+
+// decodeDeleteCommand decodes a delete command packed within a query operation
+// using the schema described in https://docs.mongodb.com/manual/reference/command/delete/#dbcmd.delete
+func decodeDeleteCommand(hdr header, nsCol NamespacedCollection, cmdArgs bson.M) (Request, error) {
+	deletesDoc, valid := cmdArgs["deletes"].([]interface{})
+	if !valid {
+		return nil, xerrors.Errorf("malformed delete command in query doc: invalid deletes list")
+	}
+
+	deleteTargets := make([]DeleteTarget, len(deletesDoc))
+	for i := 0; i < len(deletesDoc); i++ {
+		deleteDoc, valid := deletesDoc[i].(bson.D)
+		if !valid {
+			return nil, xerrors.Errorf("malformed delete command in query doc: invalid delete doc at index %d", i)
+		}
+
+		deleteDocMap := deleteDoc.Map()
+		if q, valid := deleteDocMap["q"].(bson.D); valid {
+			deleteTargets[i].Selector = q.Map()
+		}
+		if limit, valid := deleteDocMap["limit"].(int); valid {
+			deleteTargets[i].Limit = limit
+		}
+	}
+
+	req := &DeleteRequest{
+		requestBase: requestBase{h: hdr, reqType: RequestTypeDelete, replyExpected: true},
+		Collection:  nsCol,
+		Deletes:     deleteTargets,
+	}
+
+	return req, nil
+}
+
+// decodeFindCommand decodes a delete command packed within a query operation
+// using the schema described in https://docs.mongodb.com/manual/reference/command/find/#dbcmd.find
+func decodeFindCommand(hdr header, nsCol NamespacedCollection, cmdArgs bson.M) (Request, error) {
+	var numToSkip, numToReturn int32
+	if skip, valid := cmdArgs["skip"].(int); valid {
+		numToSkip = int32(skip)
+	}
+	if limit, valid := cmdArgs["limit"].(int); valid {
+		numToReturn = int32(limit)
+	}
+
+	req := &QueryRequest{
+		requestBase: requestBase{h: hdr, reqType: RequestTypeQuery, replyExpected: true},
+		Collection:  nsCol,
+		NumToSkip:   numToSkip,
+		NumToReturn: numToReturn,
+	}
+
+	if filter, valid := cmdArgs["filter"].(bson.D); valid {
+		req.Query = filter.Map()
+	}
+	if projection, valid := cmdArgs["projection"].(bson.D); valid {
+		req.FieldSelector = projection.Map()
+	}
+	if sort, valid := cmdArgs["sort"].(bson.D); valid {
+		req.Sort = sort.Map()
+	}
+
+	return req, nil
+}

--- a/protocol/decode_op.go
+++ b/protocol/decode_op.go
@@ -28,10 +28,11 @@ var (
 	//
 	// See https://docs.mongodb.com/manual/reference/command
 	cmdDecoder = map[string]func(header, NamespacedCollection, bson.M) (Request, error){
-		"insert": decodeInsertCommand,
-		"update": decodeUpdateCommand,
-		"delete": decodeDeleteCommand,
-		"find":   decodeFindCommand,
+		"insert":        decodeInsertCommand,
+		"update":        decodeUpdateCommand,
+		"delete":        decodeDeleteCommand,
+		"find":          decodeFindCommand,
+		"findAndModify": decodeFindAndModifyCommand,
 	}
 )
 

--- a/protocol/decode_op.go
+++ b/protocol/decode_op.go
@@ -1,0 +1,405 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"io/ioutil"
+	"strings"
+
+	"golang.org/x/xerrors"
+	"gopkg.in/mgo.v2/bson"
+)
+
+var (
+	// Register decoders for known mongo opcodes. If the decoder encounters
+	// an unknown opcode, it will fallback to calling decodeUnknownOp.
+	//
+	// See https://docs.mongodb.com/manual/reference/mongodb-wire-protocol.
+	opDecoder = map[int32]func(header, io.Reader) (Request, error){
+		2001: decodeUpdateOp,
+		2002: decodeInsertOp,
+		2005: decodeGetMoreOp,
+		2006: decodeDeleteOp,
+		2007: decodeKillCursorsOp,
+	}
+)
+
+// Decode a request sent in by a mongo client.
+func Decode(req []byte) (Request, error) {
+	r := bytes.NewReader(req)
+
+	hdr, err := decodeHeader(r)
+	if err != nil {
+		return nil, xerrors.Errorf("unable to decode request header: %w", err)
+	}
+
+	dec := opDecoder[hdr.opcode]
+	if dec == nil {
+		dec = decodeUnknownOp
+	}
+
+	// Pass the request body to the opcode decoder func
+	decodedReq, err := dec(hdr, r)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodedReq, nil
+}
+
+// decodeHeader reads a mongo request header from r.
+func decodeHeader(r io.Reader) (header, error) {
+	var hdr header
+
+	if err := binary.Read(r, binary.LittleEndian, &hdr.messageLength); err != nil {
+		return header{}, xerrors.Errorf("unable to read message length field: %w", err)
+	}
+	if err := binary.Read(r, binary.LittleEndian, &hdr.requestID); err != nil {
+		return header{}, xerrors.Errorf("unable to read request ID field: %w", err)
+	}
+	if err := binary.Read(r, binary.LittleEndian, &hdr.responseTo); err != nil {
+		return header{}, xerrors.Errorf("unable to read response to field: %w", err)
+	}
+	if err := binary.Read(r, binary.LittleEndian, &hdr.opcode); err != nil {
+		return header{}, xerrors.Errorf("unable to read opcode field: %w", err)
+	}
+
+	return hdr, nil
+}
+
+// decodeUpdateOp unpacks an update operation message using the following
+// schema:
+//
+//   struct OP_UPDATE {
+//       int32     ZERO;               // 0 - reserved for future use
+//       cstring   fullCollectionName; // "dbname.collectionname"
+//       int32     flags;              // bit vector. see below
+//       document  selector;           // the query to select the document
+//       document  update;             // specification of the update to perform
+//   }
+//
+// Note: the server does not send a reply for update requests.
+func decodeUpdateOp(hdr header, r io.Reader) (Request, error) {
+	// Skip reserved int32 item
+	var reserved int32
+	if err := binary.Read(r, binary.LittleEndian, &reserved); err != nil {
+		return nil, xerrors.Errorf("unable to reserved reserved field for update op: %w", err)
+	}
+
+	// Parse namespace
+	nsCol, err := decodeNamespacedCollection(r, hdr.payloadLength()-4)
+	if err != nil {
+		return nil, xerrors.Errorf("unable to read namespaced collection for update op: %w", err)
+	}
+
+	// Parse flags
+	var flags UpdateFlag
+	if err := binary.Read(r, binary.LittleEndian, &flags); err != nil {
+		return nil, xerrors.Errorf("unable to read flags for update op: %w", err)
+	}
+
+	// Read selector doc
+	selectorDoc, err := decodeBSONDocument(r)
+	if err != nil {
+		return nil, xerrors.Errorf("unable to read selector doc for update op: %w", err)
+	}
+
+	// Read update doc
+	updateDoc, err := decodeBSONDocument(r)
+	if err != nil {
+		return nil, xerrors.Errorf("unable to read update doc for update op: %w", err)
+	}
+
+	return &UpdateRequest{
+		requestBase: requestBase{h: hdr, reqType: RequestTypeUpdate},
+		Collection:  nsCol,
+		Updates: []UpdateTarget{
+			UpdateTarget{
+				Selector: selectorDoc.Map(),
+				Update:   updateDoc.Map(),
+				Flags:    flags,
+			},
+		},
+	}, nil
+}
+
+// decodeInsertOp unpacks an insert operation message using the following
+// schema:
+//
+//   struct OP_INSERT {
+//       int32     flags;              // bit vector - see below
+//       cstring   fullCollectionName; // "dbname.collectionname"
+//       document* documents;          // one or more documents to insert into the collection
+//   }
+//
+// Note: the server does not send a reply for insert requests.
+func decodeInsertOp(hdr header, r io.Reader) (Request, error) {
+	// Parse flags
+	var flags InsertFlag
+	if err := binary.Read(r, binary.LittleEndian, &flags); err != nil {
+		return nil, xerrors.Errorf("unable to read flags for insert op: %w", err)
+	}
+
+	// Parse namespace
+	nsCol, err := decodeNamespacedCollection(r, hdr.payloadLength()-4)
+	if err != nil {
+		return nil, xerrors.Errorf("unable to read namespaced collection for insert op: %w", err)
+	}
+
+	// Read list of docs to insert until we consume the entire request.
+	var docs []bson.M
+	for {
+		doc, err := decodeBSONDocument(r)
+		if err != nil {
+			if xerrors.Is(err, io.EOF) {
+				break
+			}
+			return nil, xerrors.Errorf("unable to read doc list for insert op: %w", err)
+		}
+		docs = append(docs, doc.Map())
+	}
+
+	return &InsertRequest{
+		requestBase: requestBase{h: hdr, reqType: RequestTypeInsert},
+		Collection:  nsCol,
+		Flags:       flags,
+		Inserts:     docs,
+	}, nil
+}
+
+// decodeGetMoreOp unpacks a getMore operation message using the following
+// schema:
+//
+//   struct {
+//       int32     ZERO;               // 0 - reserved for future use
+//       cstring   fullCollectionName; // "dbname.collectionname"
+//       int32     numberToReturn;     // number of documents to return
+//       int64     cursorID;           // cursorID from the OP_REPLY
+//   }
+//
+// Note: the server always sends a reply for getMore requests.
+func decodeGetMoreOp(hdr header, r io.Reader) (Request, error) {
+	// Skip reserved int32 item
+	var reserved int32
+	if err := binary.Read(r, binary.LittleEndian, &reserved); err != nil {
+		return nil, xerrors.Errorf("unable to reserved reserved field for getMore op: %w", err)
+	}
+
+	// Parse namespace
+	nsCol, err := decodeNamespacedCollection(r, hdr.payloadLength()-4)
+	if err != nil {
+		return nil, xerrors.Errorf("unable to read namespaced collection for getMore op: %w", err)
+	}
+
+	// Parse number of docs to return (batch size) and cursor ID
+	var numToReturn int32
+	if err := binary.Read(r, binary.LittleEndian, &numToReturn); err != nil {
+		return nil, xerrors.Errorf("unable to read number to return for getMore op: %w", err)
+	}
+
+	var cursorID int64
+	if err := binary.Read(r, binary.LittleEndian, &cursorID); err != nil {
+		return nil, xerrors.Errorf("unable to read cursor ID for getMore op: %w", err)
+	}
+
+	return GetMoreRequest{
+		// This request requires a reply to be sent back to the client
+		requestBase: requestBase{h: hdr, reqType: RequestTypeGetMore, replyExpected: true},
+
+		Collection:  nsCol,
+		NumToReturn: numToReturn,
+		CursorID:    cursorID,
+	}, nil
+}
+
+// decodeDeleteOp unpacks a delete operation message using the following
+// schema:
+//
+//   struct {
+//       int32     ZERO;               // 0 - reserved for future use
+//       cstring   fullCollectionName; // "dbname.collectionname"
+//       int32     flags;              // bit vector
+//       document  selector;           // query object
+//   }
+//
+// Note: the server does not send a reply for delete requests.
+func decodeDeleteOp(hdr header, r io.Reader) (Request, error) {
+	// Skip reserved int32 item
+	var reserved int32
+	if err := binary.Read(r, binary.LittleEndian, &reserved); err != nil {
+		return nil, xerrors.Errorf("unable to reserved reserved field for delete op: %w", err)
+	}
+
+	// Parse namespace
+	nsCol, err := decodeNamespacedCollection(r, hdr.payloadLength()-4)
+	if err != nil {
+		return nil, xerrors.Errorf("unable to read namespaced collection for delete op: %w", err)
+	}
+
+	// Parse flags.
+	var flags int32
+	if err := binary.Read(r, binary.LittleEndian, &flags); err != nil {
+		return nil, xerrors.Errorf("unable to read flags for delete op: %w", err)
+	}
+
+	// If bit 0 of the delete flags is set to true, we should only delete
+	// the first matching document, i.e. set limit = 1
+	var limit int
+	if flags&0x1 == 0x1 {
+		limit = 1
+	}
+
+	// Read query doc
+	queryDoc, err := decodeBSONDocument(r)
+	if err != nil {
+		return nil, xerrors.Errorf("unable to read selector doc for delete op: %w", err)
+	}
+
+	return DeleteRequest{
+		requestBase: requestBase{h: hdr, reqType: RequestTypeDelete},
+
+		Collection: nsCol,
+		Deletes: []DeleteTarget{
+			DeleteTarget{
+				Selector: queryDoc.Map(),
+				Limit:    limit,
+			},
+		},
+	}, nil
+}
+
+// decodeKillCursorsOp unpacks a killCursors operation message using the
+// following schema:
+//
+//   struct {
+//       int32     ZERO;              // 0 - reserved for future use
+//       int32     numberOfCursorIDs; // number of cursorIDs in message
+//       int64*    cursorIDs;         // sequence of cursorIDs to close
+//   }
+//
+// Note: the server does not sendsa reply for killCursors requests.
+func decodeKillCursorsOp(hdr header, r io.Reader) (Request, error) {
+	// Skip reserved int32 item
+	var reserved int32
+	if err := binary.Read(r, binary.LittleEndian, &reserved); err != nil {
+		return nil, xerrors.Errorf("unable to reserved reserved field for killCursors op: %w", err)
+	}
+
+	// Parse number cursor IDs that follow
+	var numCursors int32
+	if err := binary.Read(r, binary.LittleEndian, &numCursors); err != nil {
+		return nil, xerrors.Errorf("unable to read number of cursor IDs for killCursors op: %w", err)
+	}
+
+	// Read cursor IDs
+	var cursorIDs = make([]int64, numCursors)
+	for i := 0; i < len(cursorIDs); i++ {
+		if err := binary.Read(r, binary.LittleEndian, &cursorIDs[i]); err != nil {
+			return nil, xerrors.Errorf("unable to read cursor ID at index %d for killCurosrs op: %w", i, err)
+		}
+	}
+
+	return KillCursorsRequest{
+		requestBase: requestBase{h: hdr, reqType: RequestTypeKillCursors},
+
+		CursorIDs: cursorIDs,
+	}, nil
+}
+
+// decodeUnknownOp is invoked when the reader encounters an unknown opcode.
+func decodeUnknownOp(hdr header, r io.Reader) (Request, error) {
+	payload, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return &UnknownRequest{
+		requestBase: requestBase{h: hdr, reqType: RequestTypeUnknown},
+		Payload:     payload,
+	}, nil
+}
+
+// decodeNamespacedCollection reads a cstring from the stream and decodes it
+// into a namespaced collection instance.
+func decodeNamespacedCollection(r io.Reader, maxLen int) (NamespacedCollection, error) {
+	cstring, err := decodeCString(r, maxLen)
+	if err != nil {
+		return NamespacedCollection{}, xerrors.Errorf("unable to decode namespaced collection: %w", err)
+	}
+
+	tokens := strings.SplitN(cstring, ".", 2)
+	if len(tokens) != 2 {
+		return NamespacedCollection{}, xerrors.Errorf("unable to decode namespaced collection: malformed namespace %q", cstring)
+	} else if len(tokens[0]) == 0 {
+		return NamespacedCollection{}, xerrors.Errorf("unable to decode namespaced collection: malformed namespace %q; empty database name", cstring)
+	} else if len(tokens[1]) == 0 {
+		return NamespacedCollection{}, xerrors.Errorf("unable to decode namespaced collection: malformed namespace %q; empty collection name", cstring)
+	}
+
+	return NamespacedCollection{
+		Database:   tokens[0],
+		Collection: tokens[1],
+	}, nil
+}
+
+// decodeCString extracts a zero-terminated string from the stream or fails with
+// an error if more than maxLen characters have been read.
+func decodeCString(r io.Reader, maxLen int) (string, error) {
+	var (
+		buf       bytes.Buffer
+		totalRead int
+		nextByte  = make([]byte, 1)
+	)
+	for totalRead < maxLen {
+		n, err := r.Read(nextByte)
+		if err != nil {
+			return "", xerrors.Errorf("unable to read cstring from stream: %w", err)
+		} else if n != 1 {
+			return "", xerrors.Errorf("unable to read cstring from stream: failed to read next byte", err)
+		}
+		if nextByte[0] == 0 { // found null terminator
+			return buf.String(), nil
+		}
+		totalRead++
+		if err = buf.WriteByte(nextByte[0]); err != nil {
+			return "", xerrors.Errorf("unable to read cstring from stream: %w", err)
+		}
+	}
+
+	return "", xerrors.Errorf("unable to read cstring from stream: exceeded max allowed string length without locating null terminator")
+}
+
+func decodeBSONDocument(r io.Reader) (bson.D, error) {
+	var docSize int32
+	if err := binary.Read(r, binary.LittleEndian, &docSize); err != nil {
+		return nil, xerrors.Errorf("unable to read BSON doc from stream: %w", err)
+	} else if docSize < 4 {
+		return nil, xerrors.Errorf("unable to read BSON doc from stream: invalid doc size %d", docSize)
+	}
+
+	rawDocSize := int(docSize - 4)
+	if rawDocSize == 0 {
+		// This is just an empty document
+		return bson.D{}, nil
+	}
+
+	// Allocate buffer for the doc and prepend the size back into it as a uint32
+	doc := make([]byte, docSize)
+	binary.LittleEndian.PutUint32(doc[0:4], uint32(docSize))
+
+	// Now read the document data
+	n, err := r.Read(doc[4:])
+	if err != nil {
+		return nil, xerrors.Errorf("unable to read BSON doc from stream: %w", err)
+	} else if n != rawDocSize {
+		return nil, xerrors.Errorf("read partial BSON doc from stream: expected to read %d bytes; got %d", rawDocSize, n)
+	}
+
+	// append buffers
+	var bsonDoc bson.D
+	if err = bson.Unmarshal(doc, &bsonDoc); err != nil {
+		return nil, xerrors.Errorf("unable to unmarshal BSON doc: %w", err)
+	}
+	return bsonDoc, nil
+}

--- a/protocol/request.go
+++ b/protocol/request.go
@@ -16,6 +16,8 @@ const (
 	RequestTypeGetMore     RequestType = "getMore"
 	RequestTypeDelete      RequestType = "delete"
 	RequestTypeKillCursors RequestType = "killCursors"
+	RequestTypeQuery       RequestType = "query"
+	RequestTypeCommand     RequestType = "command"
 	RequestTypeUnknown     RequestType = "unknown"
 )
 
@@ -156,6 +158,54 @@ type KillCursorsRequest struct {
 	requestBase
 
 	CursorIDs []int64
+}
+
+// QueryFlag represents the allowed flag values for a query request.
+type QueryFlag uint32
+
+const (
+	_ QueryFlag = 1 << iota // bit 0 is reserved.
+	// Tailable means cursor is not closed when the last data is retrieved. Rather,
+	// the cursor marks the final object’s position. You can resume using the
+	// cursor later, from where it was located, if more data were received. Like
+	// any “latent cursor”, the cursor may become invalid at some point
+	// (CursorNotFound) – for example if the final object it references were
+	// deleted.
+	QueryFlagTailableCursor
+	// Allow query of replica slave. Normally these return an error except for namespace “local”.
+	QueryFlagSlaveOK
+	// Internal replication use only - driver should not set.
+	QueryFlagOplogReplay
+	// The server normally times out idle cursors after an inactivity period (10 minutes) to prevent excess memory use. Set this option to prevent that.
+	QueryFlagNoCursorTimeout
+	// Use with TailableCursor. If we are at the end of the data, block for a while rather than returning no data. After a timeout period, we do return as normal.
+	QueryFlagAwaitData
+	// Stream the data down full blast in multiple “more” packages, on the assumption that the client will fully read all data queried. Faster when you are pulling a lot of data and know you want to pull it all down. Note: the client is not allowed to not read all the data unless it closes the connection.
+	QueryFlagExhaust
+	// Get partial results from a mongos if some shards are down (instead of throwing an error)
+	QueryFlagPartial
+)
+
+// QueryRequest represents a search query.
+type QueryRequest struct {
+	requestBase
+
+	Collection    NamespacedCollection
+	Flags         QueryFlag
+	NumToSkip     int32
+	NumToReturn   int32
+	Query         bson.M
+	Sort          bson.M
+	FieldSelector bson.M
+}
+
+// CommandRequest represents a mongo command sent by a mongo client.
+type CommandRequest struct {
+	requestBase
+
+	Collection NamespacedCollection
+	Command    string
+	Args       bson.M
 }
 
 // UnknownRequest represents a client request that the parser does not know how


### PR DESCRIPTION
This PR implements a decoder for the mongo wire protocol as described in https://docs.mongodb.com/manual/reference/mongodb-wire-protocol. 

More specifically, the following opcodes are supported:

Message Type| Opcode | Description
-- | -- | --
OP_UPDATE | 2001 | Update document.
OP_INSERT | 2002 | Insert new document.
OP_QUERY | 2004 | Query a collection.
OP_GET_MORE | 2005 | Get more data from a query.
OP_DELETE | 2006 | Delete documents.
OP_KILL_CURSORS | 2007 | Notify database that the client has finished with the cursor.
OP_MSG | 2013 | Send a message using the format introduced in MongoDB 3.6.

In addition, the decoder can handle the following commands (embedded into an OP_QUERY or OP_MSG operation):

Mongo command | Coerced request type
--|--
insert | InsertRequest
update | UpdateRequest
delete | DeleteRequest
find | QueryRequest
findAndModify | FindAndUpdate or FindAndDelete

All other commands with no dedicated decoder are represented with a generic `CommandRequest`.

The PR also introduces a new cli tool for analyzing a previously recorded request stream (e.g. captured via `mongolite tools proxy -rec-requests-to reqs.bin`).
