### PR TITLE
Scaffolding work for emulating mongo

### DIFF
--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -19,7 +19,7 @@ func SetupLogger(*cli.Context) error {
 }
 
 // ExitErrorHandler is invoked when the cli encounters a fatal error.
-func ExitErrorHandler(_ *cli.Context, err error) {
+func ExitErrorHandler(err error) {
 	appLogger.WithError(err).Errorf("terminating due to error")
 	os.Exit(1)
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/achilleasa/mongolite/proxy/handler"
+	"golang.org/x/xerrors"
+	"gopkg.in/urfave/cli.v2"
+)
+
+// EmulateServer implements the serve command.
+func EmulateServer(ctx *cli.Context) error {
+	var backend handler.Backend
+
+	backendType := ctx.String("backend")
+	switch backendType {
+	case "none":
+	default:
+		return xerrors.Errorf("unsupported backend %q: supported values are: none", backendType)
+	}
+
+	appLogger.WithField("backend", backendType).Info("emulating mongo server")
+	return startProxy(ctx, handler.NewMongoEmulator(backend))
+}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"strings"
 
 	"github.com/achilleasa/mongolite/cmd"
@@ -55,9 +56,10 @@ from STDIN`,
 				},
 			},
 		},
-		Before:         cmd.SetupLogger,
-		ExitErrHandler: cmd.ExitErrorHandler,
+		Before: cmd.SetupLogger,
 	}
 
-	app.RunAndExitOnError()
+	if err := app.Run(os.Args); err != nil {
+		cmd.ExitErrorHandler(err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -20,6 +20,15 @@ func main() {
 		},
 		Commands: []*cli.Command{
 			&cli.Command{
+				Name:  "serve",
+				Usage: "Emulate a mongo server using a configurable backend",
+				Flags: []cli.Flag{
+					&cli.StringFlag{Name: "backend", Value: "none", Usage: "the type of backend to use. Ssupported backends: none"},
+				},
+				Action:   cmd.EmulateServer,
+				Category: "tools",
+			},
+			&cli.Command{
 				Name:  "tools",
 				Usage: "Helper tools",
 				Subcommands: []*cli.Command{

--- a/protocol/encode.go
+++ b/protocol/encode.go
@@ -1,0 +1,87 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+
+	"golang.org/x/xerrors"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// Encode a response for the specified request ID and write it to w.
+func Encode(w io.Writer, r Response, reqID int32) error {
+	var (
+		buf bytes.Buffer
+		hdr = header{
+			responseTo: reqID,
+			opcode:     1, // reply
+		}
+	)
+
+	// Write header; note: we will patch the length at the end
+	if err := writeHeaderTo(&buf, hdr); err != nil {
+		return xerrors.Errorf("unable to serialize reply header: %w", err)
+	}
+
+	// Write reply message
+	if err := writeResponseTo(&buf, r); err != nil {
+		return xerrors.Errorf("unable to serialize reply body: %w", err)
+	}
+
+	// Grab response data, patch the message length and write to w.
+	resData := buf.Bytes()
+	binary.LittleEndian.PutUint32(resData[0:4], uint32(len(resData)))
+	_, err := w.Write(resData)
+	return err
+}
+
+func writeHeaderTo(w io.Writer, hdr header) error {
+	if err := binary.Write(w, binary.LittleEndian, hdr.messageLength); err != nil {
+		return err
+	}
+
+	if err := binary.Write(w, binary.LittleEndian, hdr.requestID); err != nil {
+		return err
+	}
+
+	if err := binary.Write(w, binary.LittleEndian, hdr.responseTo); err != nil {
+		return err
+	}
+
+	if err := binary.Write(w, binary.LittleEndian, hdr.opcode); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func writeResponseTo(w io.Writer, r Response) error {
+	if err := binary.Write(w, binary.LittleEndian, r.Flags); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.LittleEndian, r.CursorID); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.LittleEndian, r.StartingFrom); err != nil {
+		return err
+	}
+
+	var docCount = int32(len(r.Documents))
+	if err := binary.Write(w, binary.LittleEndian, docCount); err != nil {
+		return err
+	}
+
+	// Serialize document list
+	for docIndex, doc := range r.Documents {
+		docData, err := bson.Marshal(doc)
+		if err != nil {
+			return xerrors.Errorf("unable to marshal reply doc at index %d: %w", docIndex, w)
+		}
+
+		if _, err := w.Write(docData); err != nil {
+			return xerrors.Errorf("unable to write marshaled reply doc at index %d: %w", docIndex, w)
+		}
+	}
+	return nil
+}

--- a/protocol/response.go
+++ b/protocol/response.go
@@ -1,0 +1,26 @@
+package protocol
+
+import (
+	"gopkg.in/mgo.v2/bson"
+)
+
+// ResponseFlag represents the allowed flag values for a reply message.
+type ResponseFlag uint32
+
+const (
+	// Set when getMore is called but the cursor id is not valid at the
+	// server.
+	ResponseFlagCursorNotFound ResponseFlag = 1 << iota
+
+	// Set when a query failed. The reply will include a single document
+	// with more details about the error.
+	ResponseFlagQueryError
+)
+
+// Response represents a response to a mongo client request.
+type Response struct {
+	Flags        ResponseFlag
+	CursorID     int64
+	StartingFrom int32
+	Documents    []bson.M
+}

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -7,14 +7,8 @@ import "io"
 type RequestHandler interface {
 	// HandleRequest processes the incoming request and writes a response
 	// using the mongo wire format back to the provided io.Writer.
-	HandleRequest(io.Writer, []byte) error
-}
+	HandleRequest(clientID string, w io.Writer, r []byte) error
 
-// RequestHandlerFunc is an adaptor for converting a function with a suitable
-// signature into a RequestHandler.
-type RequestHandlerFunc func(io.Writer, []byte) error
-
-// HandleRequest invokes the wrapped function with the provided arguments.
-func (f RequestHandlerFunc) HandleRequest(w io.Writer, r []byte) error {
-	return f(w, r)
+	// RemoveClient is invoked when the remote mongo client disconnects.
+	RemoveClient(clientID string) error
 }

--- a/proxy/handler/emulator.go
+++ b/proxy/handler/emulator.go
@@ -1,0 +1,152 @@
+package handler
+
+import (
+	"io"
+
+	"github.com/achilleasa/mongolite/protocol"
+	"golang.org/x/xerrors"
+	"gopkg.in/mgo.v2/bson"
+)
+
+var (
+	// ErrErrUnsupportedRequest is returned by backends when they cannot
+	// process a particular mongo client request.
+	ErrUnsupportedRequest = xerrors.New("unsupported request")
+
+	// ErrInvalidCursor is returned by backends when a request includes an
+	// unknown/invalid cursor ID.
+	ErrInvalidCursor = xerrors.New("invalid cursor")
+)
+
+// Backend is implemented by types that can emulate mongo commands and generate
+// suitable responses.
+type Backend interface {
+	// HandleRequest processes a decoded client request and returns back
+	// a Response payload.
+	HandleRequest(clientID string, req protocol.Request) (protocol.Response, error)
+
+	// RemoveClient is invoked when a particular client disconnects and
+	// allows the backend to perform any required state cleanup tasks.
+	RemoveClient(clientID string) error
+}
+
+var (
+	// A list of handlers for common mongo commands. The emulator will
+	// try to use them when a request specifies a command that the backend
+	// does not know how to handle.
+	cmdHandlers = map[string]func(string, *protocol.CommandRequest) (protocol.Response, error){}
+)
+
+// MongoEmulator emulates a mongo server by delegating CRUD requests to a
+// pluggable backend and handling a subset of common mongo commands.
+type MongoEmulator struct {
+	b Backend
+
+	// A map which stores the last seen error for each clientID
+	lastError map[string]error
+}
+
+// NewMongoEmulator returns a MongoEmulator instance that delegates CRUD
+// operations to the provided Backend instance.
+func NewMongoEmulator(b Backend) *MongoEmulator {
+	return &MongoEmulator{
+		b:         b,
+		lastError: make(map[string]error),
+	}
+}
+
+// HandleRequest implements the RequestHandler interface. This method processes
+// an incoming mongo request by first dispatching it to the configured backend.
+// If the backend is unable to handle the request, the method checks whether
+// the request includes one of the generic mongo commands supported by the
+// emulator and handles it instead.
+//
+// If an error occurs while handling a request, the emulator will first check
+// whether the request expects a response and if so, serialize the error and
+// write it back to the response stream. Otherwise, the error is buffered
+// and can be retrieved by the client via a getLastError command.
+func (emu *MongoEmulator) HandleRequest(clientID string, w io.Writer, reqData []byte) error {
+	req, err := protocol.Decode(reqData)
+	if err != nil {
+		return xerrors.Errorf("unable to decode incoming request: %w", err)
+	}
+
+	res, err := emu.process(clientID, req)
+	if err != nil {
+		emu.lastError[clientID] = err
+		if !req.ReplyExpected() {
+			return nil
+		}
+
+		res = toErrorResponse(err)
+	}
+
+	// Reset last error
+	emu.lastError[clientID] = nil
+
+	// Serialize response if this request expects one.
+	if req.ReplyExpected() {
+		return protocol.Encode(w, res, req.RequestID())
+	}
+	return nil
+}
+
+// RemoveClient implements RequestHandler. It makes sure that any
+// client-specific state tracked by the emulator or its backend is properly
+// cleaned up when the remote client disconnects.
+func (emu *MongoEmulator) RemoveClient(clientID string) error {
+	delete(emu.lastError, clientID)
+	if emu.b == nil {
+		return nil
+	}
+	return emu.b.RemoveClient(clientID)
+}
+
+func (emu *MongoEmulator) process(clientID string, req protocol.Request) (protocol.Response, error) {
+	var (
+		res protocol.Response
+		err = ErrUnsupportedRequest
+	)
+
+	if emu.b != nil {
+		res, err = emu.b.HandleRequest(clientID, req)
+	}
+
+	// The generic backend emulates some common mongo client commands.
+	// Check if this one of them.
+	if xerrors.Is(err, ErrUnsupportedRequest) {
+		if req.Type() == protocol.RequestTypeCommand {
+			return maybeProcessClientCommand(clientID, req.(*protocol.CommandRequest))
+		}
+	}
+
+	return res, err
+}
+
+// toErrorResponse converts a standard error into a mongo response payload.
+func toErrorResponse(err error) protocol.Response {
+	var flags protocol.ResponseFlag
+	if xerrors.Is(err, ErrInvalidCursor) {
+		flags |= protocol.ResponseFlagCursorNotFound
+	} else {
+		flags |= protocol.ResponseFlagQueryError
+	}
+
+	return protocol.Response{
+		Flags: flags,
+		Documents: []bson.M{
+			{"$err": err.Error()},
+		},
+	}
+}
+
+// maybeProcessClientCommand attempts to handle a mongo client command using one
+// of the registered command handlers and returns ErrUnsupportedRequest if the
+// command cannot be handled.
+func maybeProcessClientCommand(clientID string, req *protocol.CommandRequest) (protocol.Response, error) {
+	if h, found := cmdHandlers[req.Command]; found {
+		return h(clientID, req)
+	}
+
+	return protocol.Response{}, xerrors.Errorf("command %q: %w", req.Command, ErrUnsupportedRequest)
+}

--- a/proxy/handler/remote_mongo.go
+++ b/proxy/handler/remote_mongo.go
@@ -45,7 +45,7 @@ func NewRemoteMongoHandler(remoteAddr string, tlsConfig *tls.Config) (*RemoteMon
 }
 
 // HandleRequest implements RequestHandler.
-func (h *RemoteMongo) HandleRequest(w io.Writer, r []byte) error {
+func (h *RemoteMongo) HandleRequest(_ string, w io.Writer, r []byte) error {
 	// Send request
 	n, err := h.remote.Write(r)
 	if err != nil {
@@ -100,3 +100,6 @@ func (h *RemoteMongo) pipeRemoteResponse(w io.Writer) error {
 
 	return nil
 }
+
+// RemoveClient is a no-op.
+func (*RemoteMongo) RemoveClient(string) error { return nil }


### PR DESCRIPTION
This PR lays the groundwork for emulating a mongo server using a configurable backend for the CRUD logic. 

The server emulation logic also includes an escape hatch for handling common mongo commands (e.g. isMaster, getNonce, getLastError) to minimize the amount of work needed for each backend. 

No backend is provided by this PR and the fallback command list is empty. As a result, any attempt to connect with a mongo client will fail. However, you can still get to try out the response serializer for error payloads!

```console
$ go run main.go serve &
$ mongo localhost:37017
MongoDB shell version v3.6.8
connecting to: mongodb://localhost:37017/test
2020-03-31T08:43:03.959+0100 E QUERY    [thread1] Error: command "isMaster": unsupported request :
connect@src/mongo/shell/mongo.js:257:13
@(connect):1:6
exception: connect failed
```