### PR TITLE
Implement minimum command set for mongo-shell connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+*.bin
+*.pem
+mongo.dat/

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -17,6 +17,7 @@ func EmulateServer(ctx *cli.Context) error {
 		return xerrors.Errorf("unsupported backend %q: supported values are: none", backendType)
 	}
 
-	appLogger.WithField("backend", backendType).Info("emulating mongo server")
-	return startProxy(ctx, handler.NewMongoEmulator(backend))
+	srvLogger := appLogger.WithField("backend", backendType)
+	srvLogger.Info("emulating mongo server")
+	return startProxy(ctx, handler.NewMongoEmulator(backend, srvLogger))
 }

--- a/protocol/decode_cmd.go
+++ b/protocol/decode_cmd.go
@@ -23,7 +23,7 @@ func decodeInsertCommand(hdr header, nsCol NamespacedCollection, cmdArgs bson.M)
 
 	req := &InsertRequest{
 		// This request requires a reply to be sent back to the client
-		requestBase: requestBase{h: hdr, reqType: RequestTypeInsert, replyExpected: true},
+		requestBase: &requestBase{h: hdr, reqType: RequestTypeInsert, replyType: ReplyTypeOpReply},
 		Collection:  nsCol,
 		Inserts:     docs,
 	}
@@ -75,7 +75,7 @@ func decodeUpdateCommand(hdr header, nsCol NamespacedCollection, cmdArgs bson.M)
 	}
 
 	return &UpdateRequest{
-		requestBase: requestBase{h: hdr, reqType: RequestTypeUpdate, replyExpected: true},
+		requestBase: &requestBase{h: hdr, reqType: RequestTypeUpdate, replyType: ReplyTypeOpReply},
 		Collection:  nsCol,
 		Updates:     updateTargets,
 	}, nil
@@ -106,7 +106,7 @@ func decodeDeleteCommand(hdr header, nsCol NamespacedCollection, cmdArgs bson.M)
 	}
 
 	req := &DeleteRequest{
-		requestBase: requestBase{h: hdr, reqType: RequestTypeDelete, replyExpected: true},
+		requestBase: &requestBase{h: hdr, reqType: RequestTypeDelete, replyType: ReplyTypeOpReply},
 		Collection:  nsCol,
 		Deletes:     deleteTargets,
 	}
@@ -126,7 +126,7 @@ func decodeFindCommand(hdr header, nsCol NamespacedCollection, cmdArgs bson.M) (
 	}
 
 	req := &QueryRequest{
-		requestBase: requestBase{h: hdr, reqType: RequestTypeQuery, replyExpected: true},
+		requestBase: &requestBase{h: hdr, reqType: RequestTypeQuery, replyType: ReplyTypeOpReply},
 		Collection:  nsCol,
 		NumToSkip:   numToSkip,
 		NumToReturn: numToReturn,
@@ -168,7 +168,7 @@ func decodeFindAndModifyCommand(hdr header, nsCol NamespacedCollection, cmdArgs 
 	// This is a find and delete operation
 	if cmdArgs["remove"] == true {
 		return &FindAndDeleteRequest{
-			requestBase:   requestBase{h: hdr, reqType: RequestTypeFindAndDelete, replyExpected: true},
+			requestBase:   &requestBase{h: hdr, reqType: RequestTypeFindAndDelete, replyType: ReplyTypeOpReply},
 			Collection:    nsCol,
 			Query:         query,
 			Sort:          sort,
@@ -197,7 +197,7 @@ func decodeFindAndModifyCommand(hdr header, nsCol NamespacedCollection, cmdArgs 
 	}
 
 	return &FindAndUpdateRequest{
-		requestBase:      requestBase{h: hdr, reqType: RequestTypeFindAndUpdate, replyExpected: true},
+		requestBase:      &requestBase{h: hdr, reqType: RequestTypeFindAndUpdate, replyType: ReplyTypeOpReply},
 		Collection:       nsCol,
 		Query:            query,
 		Sort:             sort,

--- a/protocol/errors.go
+++ b/protocol/errors.go
@@ -1,0 +1,44 @@
+package protocol
+
+import "fmt"
+
+// ErrorCode describes the type of error messages returned by a mongo server.
+type ErrorCode int
+
+// A common subset of the error codes returned by mongo servers. The full list
+// can be found here:
+// https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.yml.
+const (
+	CodeUnauthorized         ErrorCode = 13
+	CodeNoReplicationEnabled ErrorCode = 76
+)
+
+func (ec ErrorCode) String() string {
+	switch ec {
+	case CodeUnauthorized:
+		return "Unauthorized"
+	case CodeNoReplicationEnabled:
+		return "NoReplicationEnabled"
+	default:
+		return "Unknown"
+	}
+}
+
+// ServerError describes a server error with an associated status code.
+type ServerError struct {
+	Msg  string
+	Code ErrorCode
+}
+
+// ServerErrorf creates a formatted ServerError.
+func ServerErrorf(code ErrorCode, format string, args ...interface{}) ServerError {
+	return ServerError{
+		Msg:  fmt.Sprintf(format, args...),
+		Code: code,
+	}
+}
+
+// Error returns a string representation for this error
+func (e ServerError) Error() string {
+	return fmt.Sprintf("%s (code %d): %s", e.Code.String(), e.Code, e.Msg)
+}

--- a/proxy/handler/emulator.go
+++ b/proxy/handler/emulator.go
@@ -2,9 +2,12 @@ package handler
 
 import (
 	"io"
+	"strings"
+	"time"
 
 	"github.com/achilleasa/mongolite/protocol"
 	"golang.org/x/xerrors"
+	"gopkg.in/Sirupsen/logrus.v1"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -18,6 +21,8 @@ var (
 	ErrInvalidCursor = xerrors.New("invalid cursor")
 )
 
+type cmdHandlerFn func(string, *protocol.CommandRequest) (protocol.Response, error)
+
 // Backend is implemented by types that can emulate mongo commands and generate
 // suitable responses.
 type Backend interface {
@@ -30,28 +35,47 @@ type Backend interface {
 	RemoveClient(clientID string) error
 }
 
-var (
-	// A list of handlers for common mongo commands. The emulator will
-	// try to use them when a request specifies a command that the backend
-	// does not know how to handle.
-	cmdHandlers = map[string]func(string, *protocol.CommandRequest) (protocol.Response, error){}
-)
-
 // MongoEmulator emulates a mongo server by delegating CRUD requests to a
 // pluggable backend and handling a subset of common mongo commands.
 type MongoEmulator struct {
-	b Backend
+	b      Backend
+	logger *logrus.Entry
 
 	// A map which stores the last seen error for each clientID
 	lastError map[string]error
+
+	// A list of handlers for common mongo commands. The emulator will
+	// try to use them when a request specifies a command that the backend
+	// does not know how to handle. The map keys are stored uppercased so
+	// we can handle commands in a case-insensitive manner.
+	cmdHandlers map[string]cmdHandlerFn
 }
 
 // NewMongoEmulator returns a MongoEmulator instance that delegates CRUD
 // operations to the provided Backend instance.
-func NewMongoEmulator(b Backend) *MongoEmulator {
-	return &MongoEmulator{
+func NewMongoEmulator(b Backend, logger *logrus.Entry) *MongoEmulator {
+	emu := &MongoEmulator{
 		b:         b,
+		logger:    logger,
 		lastError: make(map[string]error),
+	}
+	emu.registerCommandHandlers()
+	return emu
+}
+
+func (emu *MongoEmulator) registerCommandHandlers() {
+	allCmds := map[string]cmdHandlerFn{
+		"isMaster":         handleIsMaster,
+		"whatsMyUri":       handleWhatsMyURI,
+		"buildInfo":        handleBuildInfo,
+		"replSetGetStatus": handleReplSetGetStatus,
+		"getLog":           handleGetLog,
+	}
+
+	// Store command keys uppercased so we can perform case-insensitive lookups.
+	emu.cmdHandlers = make(map[string]cmdHandlerFn, len(allCmds))
+	for cmdName, cmdFn := range allCmds {
+		emu.cmdHandlers[strings.ToUpper(cmdName)] = cmdFn
 	}
 }
 
@@ -74,19 +98,19 @@ func (emu *MongoEmulator) HandleRequest(clientID string, w io.Writer, reqData []
 	res, err := emu.process(clientID, req)
 	if err != nil {
 		emu.lastError[clientID] = err
-		if !req.ReplyExpected() {
+		if req.ReplyType() == protocol.ReplyTypeNone {
 			return nil
 		}
 
-		res = toErrorResponse(err)
+		res = toErrorResponse(err, req.ReplyType())
 	}
 
 	// Reset last error
 	emu.lastError[clientID] = nil
 
 	// Serialize response if this request expects one.
-	if req.ReplyExpected() {
-		return protocol.Encode(w, res, req.RequestID())
+	if req.ReplyType() != protocol.ReplyTypeNone {
+		return protocol.Encode(w, res, req.RequestID(), req.ReplyType())
 	}
 	return nil
 }
@@ -116,15 +140,96 @@ func (emu *MongoEmulator) process(clientID string, req protocol.Request) (protoc
 	// Check if this one of them.
 	if xerrors.Is(err, ErrUnsupportedRequest) {
 		if req.Type() == protocol.RequestTypeCommand {
-			return maybeProcessClientCommand(clientID, req.(*protocol.CommandRequest))
+			return emu.maybeProcessClientCommand(clientID, req.(*protocol.CommandRequest))
 		}
 	}
 
 	return res, err
 }
 
+// maybeProcessClientCommand attempts to handle a mongo client command using one
+// of the registered command handlers and returns ErrUnsupportedRequest if the
+// command cannot be handled.
+func (emu *MongoEmulator) maybeProcessClientCommand(clientID string, req *protocol.CommandRequest) (protocol.Response, error) {
+	if h, found := emu.cmdHandlers[strings.ToUpper(req.Command)]; found {
+		return h(clientID, req)
+	}
+
+	emu.logger.WithFields(logrus.Fields{
+		"client_id": clientID,
+		"cmd":       req.Command,
+	}).Warn("unsupported command")
+
+	return protocol.Response{}, xerrors.Errorf("command %q: %w", req.Command, ErrUnsupportedRequest)
+}
+
+func handleIsMaster(clientID string, _ *protocol.CommandRequest) (protocol.Response, error) {
+	return protocol.Response{
+		Documents: []bson.M{{
+			"ok":                  1,
+			"ismaster":            true,
+			"secondary":           false,
+			"readOnly":            false,
+			"maxBsonObjectSize":   16 * 1024 * 1024,
+			"maxMessageSizeBytes": 48 * 1000 * 1000,
+			"maxWriteBatchSize":   10000,
+			"localTime":           time.Now().UTC(),
+			"connectionId":        clientID,
+			"minWireVersion":      1,
+			"maxWireVersion":      6,
+		}},
+	}, nil
+}
+
+func handleWhatsMyURI(clientID string, _ *protocol.CommandRequest) (protocol.Response, error) {
+	return protocol.Response{
+		Documents: []bson.M{{
+			"ok":  1,
+			"you": clientID,
+		}},
+	}, nil
+}
+
+func handleBuildInfo(string, *protocol.CommandRequest) (protocol.Response, error) {
+	return protocol.Response{
+		Documents: []bson.M{{
+			"ok": 1,
+			// We are emulating mongod 3.6.8
+			"version":           "3.6.8",
+			"versionArray":      []int{3, 6, 8, 0},
+			"maxBsonObjectSize": 16 * 1024 * 1024,
+		}},
+	}, nil
+}
+
+func handleReplSetGetStatus(_ string, req *protocol.CommandRequest) (protocol.Response, error) {
+	if req.Collection.Database != "admin" {
+		return protocol.Response{}, protocol.ServerErrorf(protocol.CodeUnauthorized, "replSetGetStatus may only be run against the admin database.")
+	}
+
+	// Emulate server with no replicas.
+	return protocol.Response{}, protocol.ServerErrorf(protocol.CodeNoReplicationEnabled, "not running with --replSet")
+}
+
+func handleGetLog(string, *protocol.CommandRequest) (protocol.Response, error) {
+	return protocol.Response{
+		Documents: []bson.M{{
+			"ok": 1,
+			// Abuse logs command to display a banner to mongo shell ;-)
+			"log": strings.Split(`
+_  _ ____ _  _ ____ ____ _    _ ___ ____ 
+|\/| |  | |\ | | __ |  | |    |  |  |___ 
+|  | |__| | \| |__] |__| |___ |  |  |___ 
+
+Greetings from your friendly neigborhood mongolite server
+WARNING: only a subset of mongo commands are working
+`, "\n"),
+		}},
+	}, nil
+}
+
 // toErrorResponse converts a standard error into a mongo response payload.
-func toErrorResponse(err error) protocol.Response {
+func toErrorResponse(err error, replyType protocol.ReplyType) protocol.Response {
 	var flags protocol.ResponseFlag
 	if xerrors.Is(err, ErrInvalidCursor) {
 		flags |= protocol.ResponseFlagCursorNotFound
@@ -132,21 +237,24 @@ func toErrorResponse(err error) protocol.Response {
 		flags |= protocol.ResponseFlagQueryError
 	}
 
+	var errDoc bson.M
+	if replyType == protocol.ReplyTypeOpReply {
+		errDoc = bson.M{"$err": err.Error()}
+	} else {
+		errDoc = bson.M{"errmsg": err.Error()}
+
+		// Server errors contain additional information.
+		if srvErr, ok := err.(protocol.ServerError); ok {
+			errDoc["errmsg"] = srvErr.Msg
+			errDoc["code"] = srvErr.Code
+			errDoc["codeName"] = srvErr.Code.String()
+		}
+	}
+
+	errDoc["ok"] = 0
+
 	return protocol.Response{
-		Flags: flags,
-		Documents: []bson.M{
-			{"$err": err.Error()},
-		},
+		Flags:     flags,
+		Documents: []bson.M{errDoc},
 	}
-}
-
-// maybeProcessClientCommand attempts to handle a mongo client command using one
-// of the registered command handlers and returns ErrUnsupportedRequest if the
-// command cannot be handled.
-func maybeProcessClientCommand(clientID string, req *protocol.CommandRequest) (protocol.Response, error) {
-	if h, found := cmdHandlers[req.Command]; found {
-		return h(clientID, req)
-	}
-
-	return protocol.Response{}, xerrors.Errorf("command %q: %w", req.Command, ErrUnsupportedRequest)
 }


### PR DESCRIPTION
This PR updates the encoder implementation in the `protocol` package to use the correct payload type (OP_REPLY or OP_MSG) when encoding responses. The choice of the reply type to use is selected at decode time (OP_QUERY and OP_GETMORE use OP_REPLY, all OP_MSG requests use OP_MSG for replies) and embedded to the decoded request instance.

What's more, the mongod emulator now supports a tiny set of mongo commands that allow mongo-shell to establish a connection and handshake with the server:

```console
$ mongo localhost:37017
MongoDB shell version v3.6.8
connecting to: mongodb://localhost:37017/test
Implicit session: session { "id" : UUID("97a869e1-c84a-4774-93d3-3e5e1ec66177") }
MongoDB server version: 3.6.8
Server has startup warnings:

_  _ ____ _  _ ____ ____ _    _ ___ ____
|\/| |  | |\ | | __ |  | |    |  |  |___
|  | |__| | \| |__] |__| |___ |  |  |___

Greetings from your friendly neigborhood mongolite server
WARNING: only a subset of mongo commands are working

>
```